### PR TITLE
Fixed overflow of links in menu when resizing browser

### DIFF
--- a/app/assets/stylesheets/cardboard/_main_topbar.css.scss
+++ b/app/assets/stylesheets/cardboard/_main_topbar.css.scss
@@ -17,7 +17,7 @@ $main_topbar_zindex: 100;
     @include border-radius(0px);
     border: none;
     padding: 0px 10px;
-    height: $main_topbar_height;
+    min-width: 760px;
     a{color: $main_topbar_color;}
     text-shadow: $main_topbar_color_text_shadow;
     


### PR DESCRIPTION
Fixed overflow of links in menu when resizing browser.  Removed specified height and set width to be no less than 760px.
