### PR TITLE
Fix Boolean Fields

### DIFF
--- a/app/models/cardboard/field/boolean.rb
+++ b/app/models/cardboard/field/boolean.rb
@@ -17,7 +17,7 @@ module Cardboard
     private
 
     def is_boolean
-      errors.add(:value, "is not a valid boolean") if value.nil?
+      errors.add(:value, "is not a valid boolean") if value_uid.nil?
     end
 
     def to_boolean(val)


### PR DESCRIPTION
Values 't', 'f', true, false, 1, 0, 'true', 'false' and nil are all valid values.  This change prevents boolean fields with values like 'some random string' from being valid.
