### PR TITLE
Fix Bug Where Pages Couldn't Find Their Children

### DIFF
--- a/app/models/cardboard/url.rb
+++ b/app/models/cardboard/url.rb
@@ -45,7 +45,7 @@ module Cardboard
     def path=(value)
       return if value.nil?
       value = value.gsub(/\//, '')
-      self[:path] = value.blank?? "/" : "/#{value}/"
+      self[:path] = value.blank?? "/" : "/#{value}"
     end
 
     def using_slug_backup?


### PR DESCRIPTION
The latest commit removing the trailing white space broke the ability for a page to find it's children via the `children` method.

This was happening because urls were being saved with a trailing slash but when you did a search using the `Url#to_s` method it wouldn't have the trailing slash.
