### PR TITLE
Expose color variables to installed cardboard.css.scss

### DIFF
--- a/app/assets/stylesheets/cardboard.css.scss
+++ b/app/assets/stylesheets/cardboard.css.scss
@@ -3,7 +3,7 @@
 // $brand_color: #f9334a;
 // $main_sidebar_background: lighten($black, 10%);
 // $main_topbar_color: $white;
-// $content_background: #f4f7f9 !default;
+// $content_background: #f4f7f9;
 
 // $black:      #000;
 // $white:      #fff;


### PR DESCRIPTION
Maybe this is just me, but passing over a few hints for styling will make quick color changes a lot simpler for devs building cardboard apps.  It's a lot easier to set $brand_color when you know it exists, compared to identifying & coloring each relevant class (like I did on my first 2 cardboard apps).
